### PR TITLE
Implement webhook signature validation

### DIFF
--- a/TrelloDotNet/TrelloDotNet/AutomationEngine/Model/ProcessingRequest.cs
+++ b/TrelloDotNet/TrelloDotNet/AutomationEngine/Model/ProcessingRequest.cs
@@ -9,14 +9,29 @@
         /// The Json from the Webhook
         /// </summary>
         public string JsonFromWebhook { get; }
+        
+        /// <summary>
+        /// The Signature from the X-Trello-Webhook header for signature validation
+        /// </summary>
+        public string Signature { get; }
+        
+        
+        /// <summary>
+        /// The Webhook URL for signature validation
+        /// </summary>
+        public string WebhookUrl { get; }
 
         /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="jsonFromWebhook">The JSON from the Webhook</param>
-        public ProcessingRequest(string jsonFromWebhook)
+        /// <param name="signature">Signature from X-Trello-Webhook header for signature validation</param>
+        /// <param name="webhookUrl">Webhook URL for signature validation</param>
+        public ProcessingRequest(string jsonFromWebhook, string signature = null, string webhookUrl = null)
         {
             JsonFromWebhook = jsonFromWebhook;
+            Signature = signature;
+            WebhookUrl = webhookUrl;
         }
     }
 }

--- a/TrelloDotNet/TrelloDotNet/Control/Webhook/WebhookSignatureValidator.cs
+++ b/TrelloDotNet/TrelloDotNet/Control/Webhook/WebhookSignatureValidator.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 
-namespace TrelloDotNet
+namespace TrelloDotNet.Control.Webhook
 {
     internal static class WebhookSignatureValidator
     {
@@ -15,10 +15,14 @@ namespace TrelloDotNet
 
         internal static bool ValidateSignature(string json, string signature, string webhookUrl, string secret)
         {
-            if (string.IsNullOrEmpty(json) || string.IsNullOrEmpty(signature) || string.IsNullOrEmpty(webhookUrl) || string.IsNullOrEmpty(secret))
-            {
-                return false;
-            }
+            if (json == null)
+                throw new ArgumentNullException(nameof(json));
+            if (signature == null)
+                throw new ArgumentNullException(nameof(signature));
+            if (webhookUrl == null)
+                throw new ArgumentNullException(nameof(webhookUrl));
+            if (secret == null)
+                throw new ArgumentNullException(nameof(secret), "You must provide an API secret to use Webhook Signature Validation. Please set TrelloClientOptions.Secret");
             
             var payloadLength = Encoding.UTF8.GetByteCount(json) + Encoding.UTF8.GetByteCount(webhookUrl);
             var payloadBytes = new byte[payloadLength];

--- a/TrelloDotNet/TrelloDotNet/Model/TrelloClientOptions.cs
+++ b/TrelloDotNet/TrelloDotNet/Model/TrelloClientOptions.cs
@@ -39,6 +39,11 @@
         /// Controls how long in seconds system should wait between retries, should it receive an 'API_TOKEN_LIMIT_EXCEEDED' error from Trello (Default 1 sec)
         /// </summary>
         public double DelayInSecondsToWaitInTokenLimitExceededRetry { get; set; }
+        
+        /// <summary>
+        /// Trello API secret for Webhook signature validation
+        /// </summary>
+        public string Secret { get; set; }
 
         /// <summary>
         /// Constructor
@@ -50,6 +55,10 @@
         /// <param name="allowDeleteOfOrganizations">Controls if it is allowed to delete Organizations (secondary confirmation)</param>
         /// <param name="maxRetryCountForTokenLimitExceeded">Controls how many automated Retries the API should try in case if get an 'API_TOKEN_LIMIT_EXCEEDED' error from Trello (Default 3) set to -1 to disable the system</param>
         /// <param name="delayInSecondsToWaitInTokenLimitExceededRetry">Controls how long in seconds system should wait between retries, should it receive an 'API_TOKEN_LIMIT_EXCEEDED' error from Trello (Default 1 sec)</param>
+        /// <param name="secret">
+        /// Trello API secret for Webhook signature validation.
+        /// When passing a secret, signature validation will be turned on for all incoming Webhooks.
+        /// </param>
         public TrelloClientOptions(
             ApiCallExceptionOption apiCallExceptionOption = ApiCallExceptionOption.IncludeUrlButMaskCredentials,
             bool allowDeleteOfBoards = false,
@@ -57,7 +66,8 @@
             bool includeAttachmentsInCardGetMethods = false,
             bool allowDeleteOfOrganizations = false,
             int maxRetryCountForTokenLimitExceeded = 3,
-            double delayInSecondsToWaitInTokenLimitExceededRetry = 1) 
+            double delayInSecondsToWaitInTokenLimitExceededRetry = 1,
+            string secret = null) 
         {
             ApiCallExceptionOption = apiCallExceptionOption;
             AllowDeleteOfBoards = allowDeleteOfBoards;
@@ -66,6 +76,7 @@
             AllowDeleteOfOrganizations = allowDeleteOfOrganizations;
             MaxRetryCountForTokenLimitExceeded = maxRetryCountForTokenLimitExceeded;
             DelayInSecondsToWaitInTokenLimitExceededRetry = delayInSecondsToWaitInTokenLimitExceededRetry;
+            Secret = secret;
         }
     }
 }

--- a/TrelloDotNet/TrelloDotNet/WebhookDataReceiver.cs
+++ b/TrelloDotNet/TrelloDotNet/WebhookDataReceiver.cs
@@ -34,11 +34,12 @@ namespace TrelloDotNet
                 return; // Most Likely the Head Call when setting up webhook - Just ignore
             }
 
-            if (_trelloClient.Options.Secret != null 
+            if ((!string.IsNullOrEmpty(signature) || !string.IsNullOrEmpty(webhookUrl))
                 && !WebhookSignatureValidator.ValidateSignature(json, signature, webhookUrl, _trelloClient.Options.Secret))
             {
                 return; // Invalid signature
             }
+            
             var webhookNotification = JsonSerializer.Deserialize<WebhookNotification>(json);
             BasicEvents.FireEvent(webhookNotification.Action);
             await SmartEvents.FireEvent(webhookNotification.Action, _trelloClient);

--- a/TrelloDotNet/TrelloDotNet/WebhookSignatureValidator.cs
+++ b/TrelloDotNet/TrelloDotNet/WebhookSignatureValidator.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace TrelloDotNet
+{
+    internal static class WebhookSignatureValidator
+    {
+        private static byte[] Digest(byte[] data, int dataIndex, int dataLength, string secret)
+        {
+            var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(secret));
+            return hmac.ComputeHash(data, dataIndex, dataLength);
+        }
+
+        internal static bool ValidateSignature(string json, string signature, string webhookUrl, string secret)
+        {
+            if (string.IsNullOrEmpty(json) || string.IsNullOrEmpty(signature) || string.IsNullOrEmpty(webhookUrl) || string.IsNullOrEmpty(secret))
+            {
+                return false;
+            }
+            
+            var payloadLength = Encoding.UTF8.GetByteCount(json) + Encoding.UTF8.GetByteCount(webhookUrl);
+            var payloadBytes = new byte[payloadLength];
+            var payloadBytesWritten = Encoding.UTF8.GetBytes(json, 0, json.Length, payloadBytes, 0);
+            payloadBytesWritten += Encoding.UTF8.GetBytes(webhookUrl, 0, webhookUrl.Length, payloadBytes, payloadBytesWritten);
+            var hashBytes = Digest(payloadBytes, 0, payloadBytesWritten, secret);
+            var signatureBytes = Convert.FromBase64String(signature);
+            return hashBytes.SequenceEqual(signatureBytes); 
+        }
+    }
+}


### PR DESCRIPTION
First proposal for implementing signature validation as documented here: https://developer.atlassian.com/cloud/trello/guides/rest-api/webhooks/#webhook-signatures

To make this usable via the Automation Engine, the validation should probably be moved to ConvertJsonToWebhookNotification.
Also I wasn't sure where the best place to put the Trello secret would be.
Please let me know your thoughts and I will move things around accordingly.

also, thanks for this library :) so far, it has been very pleasant to work with.